### PR TITLE
Update ignore handling and package version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/projectlens/__init__.py
+++ b/projectlens/__init__.py
@@ -12,8 +12,10 @@ Exported names:
     ProjectLens: The main ProjectLens class for scanning and exporting projects.
 """
 
+from importlib.metadata import version
+
 from projectlens.core import ProjectLens
 
-__version__ = "0.1.0"
+__version__ = version("projectlens")
 
-__all__ = [ProjectLens]
+__all__ = ["ProjectLens"]

--- a/projectlens/configs/.projectignore
+++ b/projectlens/configs/.projectignore
@@ -150,3 +150,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Git
+.git

--- a/projectlens/configs/config.py
+++ b/projectlens/configs/config.py
@@ -74,7 +74,7 @@ def load_ignore_patterns(ignore_file: Optional[Union[str, Path]] = None) -> set[
             for line in f:
                 line = line.strip()
                 if line and not line.startswith("#"):  # Ignore comments
-                    ignore_patterns.add(line)
+                    ignore_patterns.add(line.strip("/"))
     except Exception:
         raise
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "projectlens"
-version = "0.1.0"
+version = "0.1.1"
 description = "A tool for collecting and analyzing Python project files for LLM optimization"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Solves issues #3 and #4 .

Changes:
- ProjectLens correctly ignores folders with trailing slashes on `.projectignore`  or custom ignore file. 
- .git added to the default ignore patterns
- Automatic package version capture.
- Add Python 3.13 to the CI/CD test.